### PR TITLE
Bump Docker workflow to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/docker-image-development.yml
+++ b/.github/workflows/docker-image-development.yml
@@ -9,7 +9,7 @@ jobs:
 
   build:
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ jobs:
 
   build:
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a more recent version of the Ubuntu runner for consistency and improved support, required due to the [deprecation of the current version](https://github.com/actions/runner-images/issues/11101).

Workflow updates:

* [`.github/workflows/docker-image-development.yml`](diffhunk://#diff-1cf4c1722f7903f4087fd476d137313de4d159b1e40865c4f3c94e583edc0b8dL12-R12): Updated the `runs-on` field from `ubuntu-20.04` to `ubuntu-22.04` in the `build` job.
* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL10-R10): Updated the `runs-on` field from `ubuntu-20.04` to `ubuntu-22.04` in the `build` job.